### PR TITLE
Add Ubuntu 14.04

### DIFF
--- a/ubuntu-14.04/post_install.sh
+++ b/ubuntu-14.04/post_install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo password | sudo -S curl -o /etc/rc.local https://raw.githubusercontent.com/viglesiasce/cloud-images/master/utils/rc.local
+echo password | sudo -S chmod +x /etc/rc.local
+
+echo "passwd -l vagrant" > /tmp/shutdown
+echo "rm /tmp/shutdown" >> /tmp/shutdown
+echo "shutdown -P now" >> /tmp/shutdown

--- a/ubuntu-14.04/preseed.cfg
+++ b/ubuntu-14.04/preseed.cfg
@@ -1,0 +1,80 @@
+# Some inspiration:
+# * https://github.com/chrisroberts/vagrant-boxes/blob/master/definitions/precise-64/preseed.cfg
+# * https://github.com/cal/vagrant-ubuntu-precise-64/blob/master/preseed.cfg
+
+# English plx
+d-i debian-installer/language string en
+d-i debian-installer/locale string en_US.UTF-8
+d-i localechooser/preferred-locale string en_US.UTF-8
+d-i localechooser/supported-locales en_US.UTF-8
+
+# Including keyboards
+d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/layout select USA
+d-i keyboard-configuration/variant select USA
+d-i keyboard-configuration/modelcode string pc105
+
+
+# Just roll with it
+d-i netcfg/get_hostname string this-host
+d-i netcfg/get_domain string this-host
+
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+
+# Choices: Dialog, Readline, Gnome, Kde, Editor, Noninteractive
+d-i debconf debconf/frontend select Noninteractive
+
+d-i pkgsel/install-language-support boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+
+# Stuck between a rock and a HDD place
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-auto/choose_recipe select atomic
+
+d-i partman/confirm_write_new_label boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+
+# Write the changes to disks and configure LVM?
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto-lvm/guided_size string max
+
+# No proxy, plx
+d-i mirror/http/proxy string
+
+# Default user, change
+d-i passwd/root-login boolean false 
+
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password password
+d-i passwd/user-password-again password password
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+# No language support packages.
+d-i pkgsel/install-language-support boolean false
+
+# Individual additional packages to install
+d-i pkgsel/include string build-essential ssh curl
+
+#For the update
+d-i pkgsel/update-policy select none
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select safe-upgrade
+
+# Go grub, go!
+d-i grub-installer/only_debian boolean true
+
+d-i finish-install/reboot_in_progress note
+

--- a/ubuntu-14.04/ubuntu-packer.json
+++ b/ubuntu-14.04/ubuntu-packer.json
@@ -1,0 +1,41 @@
+{
+  "builders": [
+  {
+  "type": "qemu",
+  "format": "raw",
+  "iso_url": "http://mirrors.kernel.org/ubuntu-releases/14.04.1/ubuntu-14.04.1-server-amd64.iso",
+  "iso_checksum": "ca2531b8cd79ea5b778ede3a524779b9",
+  "iso_checksum_type": "md5",
+  "ssh_username": "vagrant",
+  "ssh_password": "password",
+  "disk_size": "5000",
+  "http_directory" : ".",
+  "http_port_min" : 9001,
+  "http_port_max" : 9001,
+  "shutdown_command": "echo password | sudo -S sh /tmp/shutdown",
+  "vm_name": "ubuntu-trusty-base",
+  "disk_interface": "virtio",
+  "qemu_binary": "../utils/fake-qemu",
+  "headless": true,
+  "accelerator": "kvm",
+  "qemuargs": [["-machine", "type=pc,accel=kvm"],
+               ["-device", "virtio-net-pci,netdev=user.0"]],
+  "boot_command" : [
+            "<esc><esc><enter><wait>",
+            "/install/vmlinuz noapic ",
+            "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+            "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+            "hostname=ubuntu ",
+            "fb=false debconf/frontend=noninteractive ",
+            "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+            "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+            "initrd=/install/initrd.gz -- <enter>"
+        ]  
+  }
+ ],
+  "provisioners": [
+  {
+    "type": "shell",
+    "script": "post_install.sh"
+  }]
+}


### PR DESCRIPTION
Using the ubuntu-12.04 template with the ubuntu 14.04.1 iso fails
since packer fails to authenticate with the VM as root. This patch
set is based on the 12.04 template with the following changes:

root now disabled in preseed.cfg

ubuntu-packer.json ssh_username changed to vagrant.
shutdown_command changed to use sudo. vm_name and iso updated.

post_install.sh updated to use sudo and to build custom one-time
shutdown script in /tmp. This is needed since locking the vagrant
user before calling shutdown causes the vm build to fail.
